### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,8 @@ jobs:
   publish-go-pkg:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/myerscode/aws-meta/security/code-scanning/7](https://github.com/myerscode/aws-meta/security/code-scanning/7)

To fix the issue, we'll explicitly define the permissions for the `publish-go-pkg` job in the `.github/workflows/release.yml` file. The job only needs read permissions for the `contents` scope, as it performs read-only operations like running `go list -m`. We'll add a `permissions` block to the `publish-go-pkg` job with `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
